### PR TITLE
Rework NavControl

### DIFF
--- a/romantic-revolutionaries/navcont.py
+++ b/romantic-revolutionaries/navcont.py
@@ -1,7 +1,15 @@
 """Navigation Controller Module"""
+from enum import Enum
 
 
-class NavControl():
+class Directions(Enum):
+    NORTH = 0
+    EAST = 1
+    SOUTH = 2
+    WEST = 3
+
+
+class NavControl:
     """Control navigation requests.
 
         To subscribe pass your callback function to subscribe()
@@ -16,10 +24,11 @@ class NavControl():
         it will repeat the last direction. If you want to call with a distance
         but no direction, you must do so with named argument for your distance.
     """
+
     def __init__(self):
-        self.callbacks=set()
-        self.direction = 'N'
-        self.distance = 1
+        self.callbacks = set()
+        self.last_distance = 1
+        self.last_direction = Directions.NORTH
 
     def subscribe(self, callback):
         self.callbacks.add(callback)
@@ -27,17 +36,21 @@ class NavControl():
     def unsubscribe(self, callback):
         self.callbacks.remove(callback)
 
-    def notify(self):
+    def _notify(self, direction, distance):
         for callback in self.callbacks:
-            callback(self.direction, self.distance)
+            callback(direction, distance)
 
-    def go(self, direction='*', distance=0):
-        if direction != '*':
-            direction = direction.upper()
-            if direction not in "NSEW":
-                raise(ValueError)
+    def go(self, direction: Directions = None, distance: int = None):
+        direction = self.last_direction if direction is None else direction
+        distance = self.last_distance if distance is None else distance
 
-            self.direction = direction
-        if distance != 0:
-            self.distance = distance
-        self.notify()
+        if not isinstance(direction, Directions):
+            raise ValueError("Direction must a value of Directions")
+
+        if distance == 0:
+            raise ValueError("Distance can not be 0")
+
+        self.last_direction = direction
+        self.last_distance = distance
+
+        self._notify(direction, distance)

--- a/romantic-revolutionaries/test_navcontrol.py
+++ b/romantic-revolutionaries/test_navcontrol.py
@@ -4,65 +4,61 @@
    from within the same directory.
 """
 
-
 import unittest
-import navcont
+
+from navcont import NavControl, Directions
+
 
 # This observer is purely to retrieve callbacks for testing
-class Observer():
+class Observer:
     def __init__(self):
-        self.direction = ''
-        self.distance=-1
+        self.direction = None
+        self.distance = None
 
     def callback(self, direction, distance):
         self.direction = direction
         self.distance = distance
 
+
 class TestNavControl(unittest.TestCase):
+    def setUp(self):
+        self.observer = Observer()
+        self.nav_control = NavControl()
 
-    def test_go(self):
-        ob = Observer()
-        nc = navcont.NavControl()
+        self.nav_control.subscribe(self.observer.callback)
 
-        nc.subscribe(ob.callback)
+    def test_defaults(self):
+        self.nav_control.go()
 
-        # Test initial defaults
-        nc.go()
-        self.assertEqual(ob.direction, 'N')
-        self.assertEqual(ob.distance, 1)
+        self.assertEqual(self.observer.direction, Directions.NORTH)
+        self.assertEqual(self.observer.distance, 1)
 
-        # Test lower case call
-        nc.go('e', 4)
-        self.assertEqual(ob.direction, 'E')
-        self.assertEqual(ob.distance, 4)
+    def test_repeat_distance(self):
+        self.nav_control.go(Directions.SOUTH, 5)
 
-        # Test repeat previous distance
-        nc.go('S')
-        self.assertEqual(ob.direction, 'S')
-        self.assertEqual(ob.distance, 4)
+        self.assertEqual(self.observer.direction, Directions.SOUTH)
+        self.assertEqual(self.observer.distance, 5)
 
-        # Test repeat previous direction
-        nc.go(distance=99)
-        self.assertEqual(ob.direction, 'S')
-        self.assertEqual(ob.distance, 99)
+        self.nav_control.go(Directions.NORTH)
 
-        # Test upper and lower case directions
-        nc.go('N')
-        self.assertEqual(ob.direction, 'N')
-        nc.go('S')
-        self.assertEqual(ob.direction, 'S')
-        nc.go('E')
-        self.assertEqual(ob.direction, 'E')
-        nc.go('W')
-        self.assertEqual(ob.direction, 'W')
-        nc.go('n')
-        self.assertEqual(ob.direction, 'N')
-        nc.go('s')
-        self.assertEqual(ob.direction, 'S')
-        nc.go('e')
-        self.assertEqual(ob.direction, 'E')
-        nc.go('w')
-        self.assertEqual(ob.direction, 'W')
+        self.assertEqual(self.observer.direction, Directions.NORTH)
+        self.assertEqual(self.observer.distance, 5)
 
-        # Test exception
-        self.assertRaises(ValueError, nc.go, 'q')
+    def test_repeat_direction(self):
+        self.nav_control.go(Directions.SOUTH, 5)
+
+        self.assertEqual(self.observer.direction, Directions.SOUTH)
+        self.assertEqual(self.observer.distance, 5)
+
+        self.nav_control.go(distance=100)
+
+        self.assertEqual(self.observer.direction, Directions.SOUTH)
+        self.assertEqual(self.observer.distance, 100)
+
+    def test_invalid_direction(self):
+        with self.assertRaises(ValueError):
+            self.nav_control.go(direction="bruh")
+
+    def test_invalid_distance(self):
+        with self.assertRaises(ValueError):
+            self.nav_control.go(distance=0)


### PR DESCRIPTION
I reworked NavControl to use an Enum for Directions, this will make it a lot easier to add directions in the future if say we wanted to add NE or something. I also reworked the tests so that they are modular and take advantage of UnitTests setUp and fixed some code formatting stuff. 